### PR TITLE
Première version du transfert capteur -> gateway

### DIFF
--- a/Task03/gateway/forward.py
+++ b/Task03/gateway/forward.py
@@ -1,0 +1,31 @@
+import digitalio
+import board
+import busio
+import adafruit_rfm9x
+import struct
+import time
+import requests
+
+RADIO_FREQ_MHZ = 868.0
+CS = digitalio.DigitalInOut(board.D5)
+RESET = digitalio.DigitalInOut(board.D6)
+
+BASE_URL = "http://192.168.2.107:3000/sensors/"
+GW_KEY = "firstGatewayKey"
+SENSOR_MAP = {
+        b"T": 1
+}
+
+spi = busio.SPI(board.SCK, MOSI=board.MOSI, MISO=board.MISO)
+rfm9x = adafruit_rfm9x.RFM9x(spi, CS, RESET, RADIO_FREQ_MHZ)
+
+while True:
+    packet = rfm9x.receive(with_header=True)
+
+    if packet is not None:
+        (s_type, s_val) = struct.unpack("<cfx", packet[4:])
+        print(s_type)
+        endpoint = BASE_URL + str(SENSOR_MAP[s_type]) + "/datas"
+        headers = { "Authorization": "Bearer " + GW_KEY }
+        req = requests.post(endpoint, headers = headers, json = { "value": s_val, "createdAt": round(time.time() * 1000) })
+        print(req.status_code)

--- a/Task03/rf95_arduino/rf95_arduino.ino
+++ b/Task03/rf95_arduino/rf95_arduino.ino
@@ -1,0 +1,133 @@
+/*
+ * Program that sends a simple message using RFM95,
+ * and then goes to sleep for a second, and sends it again.
+ * 
+ * This demo was made to test electrical consumption
+ * when send something every second.
+ * 
+ * Pinout:
+ * 
+ * | RFM95 | Arduino |
+ *   3.3V ---> 3V3
+ *   Gnd ----> Gnd
+ *   MISO ---> D12
+ *   MOSI ---> D11
+ *   SCK ----> D13
+ *   NSS ----> D4
+ *   DIO0 ---> D3
+ *   RESET --> D6
+ *   
+ * To measure consumption, transfer the program,
+ * and power the Arduino standalone using power supply
+ * connected to 1 Ohm resistor going to Arduino.
+ * 
+ * Visualize the potential between the resistor's pins
+ * to see current shape (1 V / A).
+ */
+
+#include <SPI.h>
+#include <RH_RF95.h>
+
+#include <avr/interrupt.h>
+#include <avr/sleep.h>
+#include <avr/power.h>
+
+#define RFM95_INT 3
+#define RFM95_CS  4
+#define RFM95_RST 6
+
+// Singleton instance of the radio driver
+RH_RF95 rf95(RFM95_CS, RFM95_INT);
+
+void setup() {
+  // Reset watchdog in case of brown-out during interrupt
+  wdt_rst();
+  
+  Serial.begin(9600);
+  while (!Serial); // Wait for serial port to be available
+
+  Serial.println(SCK);
+  Serial.println(MISO);
+
+  // Perform chip reset
+  digitalWrite(RFM95_RST, LOW);
+  delay(10);
+  digitalWrite(RFM95_RST, HIGH);
+  delay(10);
+  
+  if(!rf95.init()) {
+    Serial.println("init failed");
+    while(1);
+  }
+  // Defaults after init are 434.0MHz, 13dBm, Bw = 125 kHz, Cr = 4/5, Sf = 128chips/symbol, CRC on
+
+  if(!rf95.setFrequency(868.0)) {
+    Serial.println("frequency set failed");
+    while(1);
+  }
+}
+
+void loop() {
+  uint8_t data[] = "Hello World!";
+  uint8_t buf[RH_RF95_MAX_MESSAGE_LEN];
+  uint8_t len = sizeof(buf);
+
+  Serial.println("sending message");
+  if(!rf95.send(data, sizeof(data))) {
+    Serial.println("unable to send message");
+    while(1);
+  }
+  rf95.waitPacketSent();
+
+  // Wait for a reply
+  if(rf95.waitAvailableTimeout(3000)) {
+    if(rf95.recv(buf, &len)) {
+      Serial.print("got reply!");
+    }
+  }
+
+  deepsleep();
+}
+
+void wdt_rst(void) {
+  cli();
+  __asm__("wdr");
+  
+  // Clear WDRF & WDE bits
+  MCUSR &= ~0x08;
+  WDTCSR |= 0x18;
+  __asm__("nop");
+  WDTCSR = 0x00;
+
+  sei();
+}
+
+void deepsleep(void) {
+  cli();
+  
+  // Enable watchdog interrupt
+  WDTCSR |= 0x18;
+  __asm__("nop");
+  WDTCSR |= 0x4E;
+
+  // Set sleep for LoRa module
+  if(!rf95.sleep()) {
+    Serial.println("could not go to sleep");
+    while(1);
+  }
+
+  // Go to sleep
+  set_sleep_mode(SLEEP_MODE_PWR_SAVE);
+  sleep_enable();
+  sei();
+  sleep_mode();
+
+  // On deepsleep end, restart from here: reenable power
+  sleep_disable();
+  power_all_enable();
+}
+
+// Interrupt on watchdog restore (end of sleep)
+ISR(WDT_vect) {
+  wdt_rst();
+}

--- a/Task04/seeders/20200423142707-dummy-keys.js
+++ b/Task04/seeders/20200423142707-dummy-keys.js
@@ -16,8 +16,6 @@ module.exports = {
 				updatedAt: new Date(),
 			},
 			{
-				// without this key, no one can access the others
-				// please choose it secured in the first place
 				key: "githubSecretKey",
 				groupId: 3,
 				gatewayId: null,
@@ -26,7 +24,7 @@ module.exports = {
 				updatedAt: new Date(),
 			},
 			{
-				key: cryptoRandomString({length: 64, type: "base64"}),
+				key: "firstGatewayKey",
 				groupId: 2,
 				gatewayId: 1,
 				description: "Accès pour la gateway 1",


### PR DESCRIPTION
Cette PR propose un système rudimentaire de transfert de l'information entre un Arduino (ou équivalent) et une gateway (Raspberry Pi pour le moment).

## Côté capteur

### Câblage

Un capteur de température DS18B20 est branché sur un Arduino Nano selon les câblages suivants :

* Pour le RFM95 : 
  * 3.3V ---> 3V3
  * Gnd ----> Gnd
  * MISO ---> D12
  * MOSI ---> D11
  * SCK ----> D13
  * NSS ----> D4
  * DIO0 ---> D3
  * RESET --> D6

* Pour le DS18B20 : 
  * 3.3V ----> 3V3
  * Gnd -----> Gnd
  * DATA ----> D2

Une résistance de 10kOhm doit également être attachée entre les broches 3.3V et DATA du capteur.

### Fonctionnement du code

Le code initialise d'abord le module, le capteur, puis va envoyer, toutes les 4 secondes, une valeur par radio. Entre les intervalles d'envoi, le module et l'Arduino sont en veille profonde, ce qui permet d'économiser l'énergie. La consommation moyenne est actuellement de 6mA (avec peu de différences lors de la veille) sur un microcontrôleur simple, cadencé à 4MHz et alimenté en 3V3. C'est un valeur plutôt haute, donc je pense qu'il y a un problème quelque part. Je prévois de faire un montage permettant de monitorer la consommation des différents composants, pour cerner le problème.

Afin de pouvoir compiler le code, il faut installer les bibliothèques `RadioHead`, `OneWire` et `DallasTemperature`.

## Côté gateway

La gateway est formée d'un système Linux standard installé sur une Raspberry Pi, qui exécute le code Python `gateway/forward.py`. Ce code fait un simple pooling pour la récupération de données, et les renvoie vers le serveur lorsqu'une donnée est récupérée.

Le protocole de communication radio est très simple, et consiste en une structure codant sur 6 octets le type de capteur (associé ensuite à son identifiant par la gateway) et la donnée en flottant (little-endian).