### PR TITLE
Réécriture du parseur de corps de requête

### DIFF
--- a/Task04/__tests__/authorization.test.js
+++ b/Task04/__tests__/authorization.test.js
@@ -37,38 +37,44 @@ const promisifyPlugin = (req, res) => new Promise((resolve, reject) => {
 	setTimeout(() => reject(res.stat), 1000);
 });
 
+const allowGetHeader = obj => {
+	return Object.assign({}, obj, {
+		get: prop => obj[prop],
+	});
+};
+
 describe("simple groups", () => {
 	test("disallow stranger", async () => {
 		const res = new DummyServer();
 
-		expect(promisifyPlugin({
+		expect(promisifyPlugin(allowGetHeader({
 			method: "GET",
 			path: "/disallow",
 			headers: {},
-		}, res)).rejects.toEqual(403);
+		}), res)).rejects.toEqual(403);
 	});
 
 	test("allow stranger", () => {
 		const res = new DummyServer();
 
-		expect(promisifyPlugin({
+		expect(promisifyPlugin(allowGetHeader({
 			method: "GET",
 			path: "/allow",
 			headers: {},
 		// simply calls next, without setting status code
-		}, res)).resolves.toEqual(0);
+		}), res)).resolves.toEqual(0);
 	});
 
 	test("allow admin wildcard", () => {
 		const res = new DummyServer();
 
-		expect(promisifyPlugin({
+		expect(promisifyPlugin(allowGetHeader({
 			method: "GET",
 			path: "/disallow",
 			headers: {
 				authorization: "Bearer admin",
 			},
-		}, res)).resolves.toEqual(0);
+		}), res)).resolves.toEqual(0);
 	});
 });
 
@@ -76,25 +82,25 @@ describe("url parameters", () => {
 	test("disallow invalid", () => {
 		const res = new DummyServer();
 
-		expect(promisifyPlugin({
+		expect(promisifyPlugin(allowGetHeader({
 			method: "GET",
 			path: "/disallow/0",
 			headers: {
 				// BUG: bearer is necessary to get path-perms
 				authorization: "Bearer guest",
 			},
-		}, res)).rejects.toEqual(403);
+		}), res)).rejects.toEqual(403);
 	});
 
 	test("allow authorized", () => {
 		const res = new DummyServer();
 
-		expect(promisifyPlugin({
+		expect(promisifyPlugin(allowGetHeader({
 			method: "GET",
 			path: "/disallow/1",
 			headers: {
 				authorization: "Bearer guest",
 			},
-		}, res)).resolves.toEqual(0);
+		}), res)).resolves.toEqual(0);
 	});
 });

--- a/Task04/controllers/body.js
+++ b/Task04/controllers/body.js
@@ -79,6 +79,10 @@ class BodyParser {
 		Object.assign(this.injectors, injectors);
 	}
 
+	setStrictMode(value) {
+		this.strictMode = value;
+	}
+
 	executeInjectors() {
 		const injects = {};
 

--- a/Task04/controllers/patch.js
+++ b/Task04/controllers/patch.js
@@ -1,4 +1,4 @@
-const bodyParser = require("./body");
+const BodyParser = require("./body");
 
 module.exports = config => async (req, res) => {
 	const postprocessor = typeof config.postprocessor === "function" ?
@@ -6,13 +6,16 @@ module.exports = config => async (req, res) => {
 		(d => d);
 
 	const id = req.params.modelId;
+
+	config.strict = false;
+	config.body = undefined;
+
+	const localParser = BodyParser.fromConfig(config);
+
 	let bodyOpts = {};
 
 	try {
-		bodyOpts = bodyParser(Object.assign(config, {
-			body: req.body,
-			strict: false,
-		}));
+		bodyOpts = localParser.validate(req.body);
 	} catch(message) {
 		// send client-side error
 		return res.status(400).json({ meta: { error: { message }}});

--- a/Task04/controllers/post.js
+++ b/Task04/controllers/post.js
@@ -1,14 +1,19 @@
-const bodyParser = require("./body");
+const BodyParser = require("./body");
 
 module.exports = config => (req, res) => {
 	const postprocessor = typeof config.postprocessor === "function" ?
 		config.postprocessor :
 		(d => d);
 
+	config.strict = true;
+	config.body = undefined;
+	
+	const localParser = BodyParser.fromConfig(config);
+
 	let bodyOpts = {};
 
 	try {
-		bodyOpts = bodyParser(Object.assign(config, { body: req.body }));
+		bodyOpts = localParser.validate(req.body);
 	} catch(message) {
 		// send client-side error
 		return res.status(400).json({ meta: { error: { message }}});

--- a/Task04/routes/sensors.js
+++ b/Task04/routes/sensors.js
@@ -4,6 +4,7 @@ const controllers = require("../controllers");
 const models = require("../models");
 const sequelize = require("sequelize");
 
+const formatDate = controllers.body.formatDate;
 const DataType = sequelize.DataTypes;
 const Op = sequelize.Op;
 
@@ -41,11 +42,14 @@ router.post("/:sensorId/datas", (req, res) => {
 // delete datas from date to date
 router.delete("/:sensorId/datas", (req, res) => {
 	const sensorId = req.params.sensorId;
-	const { start, end } = req.query;
+	let { start, end } = req.query;
 	const filter = {};
 
 	// filter by creation date
 	try {
+		start = formatDate(start);
+		end = formatDate(end);
+
 		DataType.DATE().validate(start);
 		DataType.DATE().validate(end);
 
@@ -56,7 +60,9 @@ router.delete("/:sensorId/datas", (req, res) => {
 			},
 		});
 	// eslint-disable-next-line no-empty
-	} catch(e) {}
+	} catch(e) {
+		console.log(e);
+	}
 
 	controllers.delete({
 		model: models.Datas,


### PR DESCRIPTION
Réécriture du parseur du corps de requête, afin

1. d'assurer une meilleure lisibilité ;
2. de faire fonctionner le *DELETE* sur les données de capteurs, via une externalisation de certaines méthodes.

### Procédure de validation

Pour confirmer le fonctionnement, il faut vérifier quelques points d'accès (GET, POST, ...), et vérifier le bon fonctionnement des dates sur le *DELETE* des données de capteurs.

Si tout fonctionne, il faut attendre que je répare les tests avant le fusionner.